### PR TITLE
Fixing omission of libiomp5.so on Linux

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,9 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-      with:
-        # This gets all branches (1 = only current branch)
-        fetch-depth: 0
     - name: Additional info about the build
       shell: bash
       run: |

--- a/.github/workflows/DevTag.yaml
+++ b/.github/workflows/DevTag.yaml
@@ -1,14 +1,16 @@
-name: BranchCI
+name: Release
 
 on:
   push:
-    branches-ignore:
-      - 'main'
-      - 'dev'
+    tags:
+      - "*"
+    branches:
+      - "dev"
 
 jobs:
-  light-ci:
-    name: Lint ubuntu-latest Py3.9
+  release:
+    name: Dev release ubuntu-latest Py3.9
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -47,4 +49,16 @@ jobs:
       with:
         file: ./coverage.xml
         flags: unittests
-        name: codecov-ubuntu-latest-py3.9
+    - name: Install pypa/build
+      run: |
+        python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python -m build --sdist --wheel --outdir dist/
+        ls -l dist/
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -12,9 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-      with:
-        # This gets all branches (1 = only current branch)
-        fetch-depth: 0
     - name: Additional info about the build
       shell: bash
       run: |

--- a/mopac_step/installer.py
+++ b/mopac_step/installer.py
@@ -145,5 +145,10 @@ class Installer(seamm_installer.InstallerBase):
         zip_archive = zipfile.ZipFile(zip_file)
         zip_archive.extract("MOPAC2016.exe", path)
 
+        if system == "Linux":
+            zip_archive.extract("libiomp5.so", path)
+            lib_path = path / "libiomp5.so"
+            lib_path.chmod(0o755)
+
         mopac_exe = path / "MOPAC2016.exe"
         mopac_exe.chmod(0o755)

--- a/mopac_step/mopac.py
+++ b/mopac_step/mopac.py
@@ -156,6 +156,7 @@ class MOPAC(seamm.Node):
                 Path(options["mopac_path"]).expanduser().resolve()
                 / options["mopac_exe"]
             )
+        mopac_path = Path(mopac_exe).parent.expanduser().resolve()
 
         # How many processors does this node have?
         n_cores = psutil.cpu_count(logical=False)
@@ -193,6 +194,7 @@ class MOPAC(seamm.Node):
         self.logger.info(f"MOPAC will use {mopac_num_threads} threads.")
 
         env = {
+            "LD_LIBRARY_PATH": str(mopac_path),
             "MKL_NUM_THREADS": str(mkl_num_threads),
             "OMP_NUM_THREADS": str(mopac_num_threads),
         }


### PR DESCRIPTION
On some systems, libiomp5.so is not present. The solution is to extract it for the distribution zip file alongside the executable and correctly set the LD_LIBRARY_PATH when running.

Also changing the CI to release tagged releases on the dev branch to Test PyPi.