### PR TITLE
Hotfix for bug with configuration names

### DIFF
--- a/mopac_step/ir.py
+++ b/mopac_step/ir.py
@@ -90,7 +90,8 @@ class IR(mopac_step.Energy):
         elif confname == "use configuration number":
             text += "using the index of the configuration (1, 2, ...) as its name."
         else:
-            text += "with '{confname}' as its name."
+            confname = confname.replace("<Hamiltonian>", P["hamiltonian"])
+            text += f"with '{confname}' as its name."
 
         return self.header + "\n" + __(text, **P, indent=4 * " ").__str__()
 
@@ -163,16 +164,18 @@ class IR(mopac_step.Energy):
 
             # And the name of the configuration.
             if "configuration name" in P:
-                if P["configuration name"] == "vibrations with <Hamiltonian>":
-                    configuration.name = f"vibrations with {P['hamiltonian']}"
-                elif P["configuration name"] == "keep current name":
-                    pass
-                elif P["configuration name"] == "use SMILES string":
+                if P["configuration name"] == "use SMILES string":
                     configuration.name = configuration.smiles
                 elif P["configuration name"] == "use Canonical SMILES string":
                     configuration.name = configuration.canonical_smiles
-                elif P["configuration name"] == "use configuration number":
-                    configuration.name = str(configuration.n_configurations)
+                elif P["configuration name"] == "keep current name":
+                    pass
+                elif P["configuration name"] == "vibrations with <Hamiltonian>":
+                    configuration.name = f"vibrations with {P['hamiltonian']}"
+                else:
+                    confname = P["configuration name"]
+                    confname = confname.replace("<Hamiltonian>", P["hamiltonian"])
+                    configuration.name = confname
 
         # Write the structure out for viewing.
         directory = Path(self.directory)

--- a/mopac_step/mopac.py
+++ b/mopac_step/mopac.py
@@ -402,14 +402,12 @@ class MOPAC(seamm.Node):
         out = []
         start = 0
         lineno = 0
-        n_star_lines = 0
         for line in lines:
-            if line[1:51] == 50 * "*":
-                n_star_lines += 1
-                if n_star_lines == 7:
-                    out.append(lines[start:lineno])
-                    start = lineno
-                    n_star_lines = 0
+            if "** Cite this program as:" in line:
+                if lineno == 2:
+                    continue
+                out.append(lines[start : lineno - 1])
+                start = lineno - 2
             lineno += 1
         out.append(lines[start:])
 
@@ -448,7 +446,13 @@ class MOPAC(seamm.Node):
             for value in node.description:
                 printer.important(value)
 
-            node.analyze(data=data, out=out[section])
+            if section >= len(out):
+                logger.error(
+                    "Could not find the MOPAC output for subjob {section + 1}/"
+                )
+                node.analyze(data=data, out="")
+            else:
+                node.analyze(data=data, out=out[section])
 
             printer.normal("")
 

--- a/mopac_step/optimization.py
+++ b/mopac_step/optimization.py
@@ -81,7 +81,8 @@ class Optimization(mopac_step.Energy):
         elif confname == "use configuration number":
             text += "using the index of the configuration (1, 2, ...) as its name."
         else:
-            text += "with '{confname}' as its name."
+            confname = confname.replace("<Hamiltonian>", P["hamiltonian"])
+            text += f"with '{confname}' as its name."
 
         return self.header + "\n" + __(text, **P, indent=4 * " ").__str__()
 
@@ -263,16 +264,18 @@ class Optimization(mopac_step.Energy):
 
             # And the name of the configuration.
             if "configuration name" in P:
-                if P["configuration name"] == "optimized with <Hamiltonian>":
-                    configuration.name = f"optimized with {P['hamiltonian']}"
-                elif P["configuration name"] == "keep current name":
-                    pass
-                elif P["configuration name"] == "use SMILES string":
+                if P["configuration name"] == "use SMILES string":
                     configuration.name = configuration.smiles
                 elif P["configuration name"] == "use Canonical SMILES string":
                     configuration.name = configuration.canonical_smiles
-                elif P["configuration name"] == "use configuration number":
-                    configuration.name = str(configuration.n_configurations)
+                elif P["configuration name"] == "keep current name":
+                    pass
+                elif P["configuration name"] == "optimized with <Hamiltonian>":
+                    configuration.name = f"optimized with {P['hamiltonian']}"
+                else:
+                    confname = P["configuration name"]
+                    confname = confname.replace("<Hamiltonian>", P["hamiltonian"])
+                    configuration.name = confname
 
         # Write the structure out for viewing.
         directory = Path(self.directory)

--- a/mopac_step/thermodynamics.py
+++ b/mopac_step/thermodynamics.py
@@ -94,7 +94,8 @@ class Thermodynamics(mopac_step.Energy):
         elif confname == "use configuration number":
             text += "using the index of the configuration (1, 2, ...) as its name."
         else:
-            text += "with '{confname}' as its name."
+            confname = confname.replace("<Hamiltonian>", P["hamiltonian"])
+            text += f"with '{confname}' as its name."
 
         return self.header + "\n" + __(text, **P, indent=4 * " ").__str__()
 
@@ -171,16 +172,18 @@ class Thermodynamics(mopac_step.Energy):
 
             # And the name of the configuration.
             if "configuration name" in P:
-                if P["configuration name"] == "vibrations with <Hamiltonian>":
-                    configuration.name = f"vibrations with {P['hamiltonian']}"
-                elif P["configuration name"] == "keep current name":
-                    pass
-                elif P["configuration name"] == "use SMILES string":
+                if P["configuration name"] == "use SMILES string":
                     configuration.name = configuration.smiles
                 elif P["configuration name"] == "use Canonical SMILES string":
                     configuration.name = configuration.canonical_smiles
-                elif P["configuration name"] == "use configuration number":
-                    configuration.name = str(configuration.n_configurations)
+                elif P["configuration name"] == "keep current name":
+                    pass
+                elif P["configuration name"] == "vibrations with <Hamiltonian>":
+                    configuration.name = f"vibrations with {P['hamiltonian']}"
+                else:
+                    confname = P["configuration name"]
+                    confname = confname.replace("<Hamiltonian>", P["hamiltonian"])
+                    configuration.name = confname
 
         # Write the structure out for viewing.
         directory = Path(self.directory)


### PR DESCRIPTION
Fixed two bugs:

- A bug using general names for configurations failed.
- A bug in parsing the output file caused a failure is 4 or more subjobs in a single MOPAC run