### PR TITLE
Updated for changes in MOPAC v2022.1.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2023.11.14 -- Updated for MOPAC v2022.1.0
+  * MOPAC v2022.1.0 added GRADIENT_NORM_UPDATED to the AUX file. This updates adds it to
+    the results recognized by the plug-in
+    
 2023.10.30 -- Updated to standard structure handling
   * Adds IUPAC names, InChI and InChIKey as possible names for configurations
   * Cleaned up output to be properly indented and laid out.

--- a/mopac_step/metadata.py
+++ b/mopac_step/metadata.py
@@ -1498,6 +1498,13 @@ metadata["results"] = {
         "type": "float",
         "units": "kcal/mol/Å",
     },
+    "GRADIENT_NORM_UPDATED": {
+        "calculation": ["optimization"],
+        "description": "current norm of the gradient",
+        "dimensionality": "scalar",
+        "type": "float",
+        "units": "kcal/mol/Å",
+    },
     "GRADIENT_UPDATED": {
         "calculation": ["optimization"],
         "description": "forces in trajectory",


### PR DESCRIPTION
* MOPAC v2022.1.0 added GRADIENT_NORM_UPDATED to the AUX file. This updates adds it to the results recognized by the plug-in