### PR TITLE
Finalized the handling of the MOPAC executable for direct execution and Docker containers

### DIFF
--- a/devtools/docker/Dockerfile
+++ b/devtools/docker/Dockerfile
@@ -4,4 +4,5 @@ COPY ./environment.yml /root/environment.yml
 
 RUN mamba env update -f /root/environment.yml
 
-CMD mopac mopac.dat
+ENTRYPOINT ["mopac"]
+CMD ["mopac.dat"]

--- a/mopac_step/data/mopac.ini
+++ b/mopac_step/data/mopac.ini
@@ -1,12 +1,35 @@
 # Configuration options for how to run MOPAC
 
 [local]
+# The code to use. This may maybe more than just the name of the code, and variables in braces
+# {} will be expanded. For example:
+#   code = mpiexec -np {NTASKS} lmp_mpi
+# would expand {NTASKS} to the number of tasks and run the command
 code = mopac
+
+# The type of local installation to use. Options are:
+#   conda: Use a conda environment
+#   modules: Use the modules system
+#   local: Use a local installation
+# By default SEAMM installs MOPAC using conda.
 installation = conda
+
+# The Conda environment to use. This is the name or full path of the environment to use.
 conda-environment = seamm-mopac
-modules = 
+
+# The modules to load to run MOPAC. This is a list of strings, each of which
+# is a module to load. For example, to load the modules mopac and openmpi,
+# you would use:
+#   modules = mopac openmpi
+# modules = 
 
 [docker]
+# The code to use. This may maybe more than just the name of the code, and variables in braces
+# {} will be expanded. For example:
+#   code = mpiexec -np {NTASKS} lmp_mpi
+# would expand {NTASKS} to the number of tasks and run the command
 code = mopac
+
+# The name and location of the Docker container to use, optionally with the version
 container = ghcr.io/molssi-seamm/seamm-mopac:latest
 

--- a/mopac_step/mopac.py
+++ b/mopac_step/mopac.py
@@ -290,7 +290,7 @@ class MOPAC(mopac_step.MOPACBase):
                     else:
                         full_config[executor_type] = {
                             "installation": "local",
-                            "code": str(path)
+                            "code": str(path),
                         }
 
                 config = dict(full_config.items(executor_type))

--- a/mopac_step/mopac.py
+++ b/mopac_step/mopac.py
@@ -5,12 +5,13 @@
 import calendar
 import configparser
 import datetime
+import importlib
 import logging
 import os
 import os.path
 from pathlib import Path
-import pkg_resources
 import pprint
+import shutil
 import string
 
 import molsystem
@@ -25,8 +26,8 @@ job = printing.getPrinter()
 printer = printing.getPrinter("mopac")
 
 # Add MOPAC's properties to the standard properties
-path = Path(pkg_resources.resource_filename(__name__, "data/"))
-csv_file = path / "properties.csv"
+resources = importlib.resources.files("mopac_step") / "data"
+csv_file = resources / "properties.csv"
 molsystem.add_properties_from_file(csv_file)
 
 
@@ -262,16 +263,36 @@ class MOPAC(mopac_step.MOPACBase):
 
                 executor = self.flowchart.executor
 
-                # Read configuration file for MOPAC
-                ini_dir = Path(seamm_options["root"]).expanduser()
-                full_config = configparser.ConfigParser()
-                full_config.read(ini_dir / "mopac.ini")
+                # Read configuration file for MOPAC if it exists
                 executor_type = executor.name
+                full_config = configparser.ConfigParser()
+                ini_dir = Path(seamm_options["root"]).expanduser()
+                path = ini_dir / "mopac.ini"
+
+                if path.exists():
+                    full_config.read(ini_dir / "mopac.ini")
+
+                # If the section we need doesn't exists, get the default
+                if not path.exists() or executor_type not in full_config:
+                    resources = importlib.resources.files("mopac_step") / "data"
+                    ini_text = (resources / "mopac.ini").read_text()
+                    full_config.read_string(ini_text)
+
+                # Getting desperate! Look for an executable in the path
                 if executor_type not in full_config:
-                    raise RuntimeError(
-                        f"No section for '{executor_type}' in MOPAC ini file "
-                        f"({ini_dir / 'mopac.ini'})"
-                    )
+                    path = shutil.which("mopac")
+                    if path is None:
+                        raise RuntimeError(
+                            f"No section for '{executor_type}' in MOPAC ini file "
+                            f"({ini_dir / 'mopac.ini'}), nor in the defaults, nor "
+                            "in the path!"
+                        )
+                    else:
+                        full_config[executor_type] = {
+                            "installation": "local",
+                            "code": str(path)
+                        }
+
                 config = dict(full_config.items(executor_type))
 
                 return_files = [


### PR DESCRIPTION
Finalized the handling of the MOPAC executable:

1. If ~/SEAMM/mopac.ini exists and it has the need information, use it.
2. Otherwise, try using the template in the data directory.
3. If that doesn't work, see if the executable is in the path.

Also switched from deprecated pkg_resources package.