### PR TITLE
Using explicit version of Docker image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,20 +53,26 @@ Features
 seamm-mopac Docker image
 ------------------------
 There is a Docker image available for the SEAMM MOPAC plug-in for running mopac. It is
-available at
+available at the Github Container Registry (ghcr.io) as
 
 .. code-block:: bash
 
-    ghcr.io/molssi-seamm/seamm-mopac:latest
+    ghcr.io/molssi-seamm/seamm-mopac:<version>
 
-It can also be run standalone with the following command:
+Where <version> is the explicit version tag for the desired image. The tag `latest` is
+quite confusing, and does not mean the latest version of the image, so we recomend using
+explcit versions rather than `latest`.
+
+The container can also be run standalone with the following command:
 
 .. code-block:: bash
 
-    docker run --rm -v $PWD:/home ghcr.io/molssi-seamm/seamm-mopac:latest <input file>
+    docker run --rm -v $PWD:/home ghcr.io/molssi-seamm/seamm-mopac:<version> ?mopac <input file>?
 
-where `<input file>` is the input file for the MOPAC calculation. By default, the input
-file is `mopac.dat`. The output files will be written to the current directory.
+where `<input file>` is the input file for the MOPAC calculation. By default, mopac is
+run using the input file `mopac.dat`. The output files will be written to the current
+directory. The `--rm` option removes the container after it exits, and the `-v` option
+mounts the current directory to the `/home` directory in the container.
 
 Acknowledgements
 ----------------
@@ -78,7 +84,7 @@ This package was created with Cookiecutter_ and the `molssi-seamm/cookiecutter-s
 
 Developed by the Molecular Sciences Software Institute (MolSSI_),
 which receives funding from the `National Science Foundation`_ under
-award ACI-1547580
+awards OAC-1547580 and CHE-2136142.
 
 .. _MolSSI: https://www.molssi.org
 .. _`National Science Foundation`: https://www.nsf.gov

--- a/devtools/docker/Dockerfile
+++ b/devtools/docker/Dockerfile
@@ -5,5 +5,4 @@ COPY ./environment.yml /root/environment.yml
 RUN mamba env update -f /root/environment.yml
 
 WORKDIR /home
-ENTRYPOINT ["mopac"]
-CMD ["mopac.dat"]
+CMD ["mopac", "mopac.dat"]

--- a/mopac_step/data/mopac.ini
+++ b/mopac_step/data/mopac.ini
@@ -31,5 +31,5 @@ conda-environment = seamm-mopac
 code = mopac
 
 # The name and location of the Docker container to use, optionally with the version
-container = ghcr.io/molssi-seamm/seamm-mopac:latest
+container = ghcr.io/molssi-seamm/seamm-mopac:{version}
 

--- a/mopac_step/mopac.py
+++ b/mopac_step/mopac.py
@@ -294,6 +294,8 @@ class MOPAC(mopac_step.MOPACBase):
                         }
 
                 config = dict(full_config.items(executor_type))
+                # Use the matching version of the seamm-mopac image by default.
+                config["version"] = self.version
 
                 return_files = [
                     "mopac.arc",


### PR DESCRIPTION
1. Migrating to using the explicit version of the seamm-mopac container that is matched to the plug-in.
2. Removed the `ENTRYPOINT` command from the Docker image and rely on just the `COMMAND` for the default.
3. Updated the README to reflect using the explicit version of the Docker image.