### PR TITLE
Bugfix for PM7-TS and optimization, GUI clean up for CI calculations.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 =======
 History
 =======
+2024.8.21 -- Bugfix for PM7-TS and optimization, GUI clean up for CI calculations.
+  * Calculations using PM7-TS do not write information to the AUX file, so added code to
+    get the energy from the output file.
+  * For optimizations, the option for the frequency of calculating the force constants
+    and the maximum radius of convergence were missing from the GUI for the EF
+    method. The frequency also was not being correctly handled in the input to MOPAC.
+  * The GUI for using CI calculations was cleaned up.
+    
 2024.8.17 -- Added CI calculations and better handling of transition states
   * Added ability to do the various types of CI calculations that MOPAC supports.
   * Improved the handling of TS calculations and added NLLSQ and SIGMA methods in

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 =======
 History
 =======
-2024.8.17 --
+2024.8.17 -- Added CI calculations and better handling of transition states
   * Added ability to do the various types of CI calculations that MOPAC supports.
   * Improved the handling of TS calculations and added NLLSQ and SIGMA methods in
     the optimization step.

--- a/mopac_step/energy.py
+++ b/mopac_step/energy.py
@@ -1115,6 +1115,17 @@ class Energy(seamm.Node):
         # Put any requested results into variables or tables
         if "HEAT_OF_FORMATION" in data:
             data["energy"] = data["HEAT_OF_FORMATION"]
+        else:
+            # See if it is in the output. PM7-TS does not write to AUX!
+            lines = iter(out_sections[0])
+            for line in lines:
+                if "FINAL HEAT OF FORMATION =" in line:
+                    try:
+                        data["HEAT_OF_FORMATION"] = float(line.split()[5])
+                        data["energy"] = data["HEAT_OF_FORMATION"]
+                    except Exception:
+                        pass
+
         if "GRADIENTS" in data:
             tmp = np.array(data["GRADIENTS"]).reshape(-1, 3)
             # Remove any translation

--- a/mopac_step/optimization.py
+++ b/mopac_step/optimization.py
@@ -139,7 +139,7 @@ class Optimization(mopac_step.Energy):
         elif method[0:2] == "EF":
             keywords.append("EF")
             if P["recalc"] != "never":
-                keywords.append(P["recalc"])
+                keywords.append(f'RECALC={P["recalc"]}')
             if str(P["dmax"]) != self.parameters["dmax"].default:
                 keywords.append("DMAX={}".format(P["dmax"]))
             references.cite(
@@ -197,6 +197,10 @@ class Optimization(mopac_step.Energy):
             )
         elif method[0:2] == "TS":
             keywords.append("TS")
+            if P["recalc"] != "never":
+                keywords.append(f'RECALC={P["recalc"]}')
+            if str(P["dmax"]) != self.parameters["dmax"].default:
+                keywords.append("DMAX={}".format(P["dmax"]))
             references.cite(
                 raw=bibliography["Baker_1986"],
                 alias="Baker_1986",

--- a/mopac_step/tk_energy.py
+++ b/mopac_step/tk_energy.py
@@ -130,6 +130,17 @@ class TkEnergy(seamm.TkNode):
                 widgets.append(self[key])
                 row += 1
 
+        if "ci" in calculation.lower():
+            for key in (
+                "number ci orbitals",
+                "number doubly occupied ci orbitals",
+                "ci root",
+                "print ci details",
+            ):
+                self[key].grid(row=row, column=0, columnspan=2, sticky=tk.EW)
+                widgets.append(self[key])
+                row += 1
+
         for key in ("convergence",):
             self[key].grid(row=row, column=0, columnspan=2, sticky=tk.EW)
             widgets.append(self[key])
@@ -160,20 +171,9 @@ class TkEnergy(seamm.TkNode):
                 row += 1
             if mozyme != "never":
                 self["MOZYME follow-up"].grid(row=row, column=1, sticky=tk.W)
-                subwidgets.append(self["MOZYME"])
+                subwidgets.append(self["MOZYME follow-up"])
                 row += 1
             sw.align_labels(subwidgets, sticky=tk.E)
-
-        if "ci" in calculation.lower():
-            for key in (
-                "number ci orbitals",
-                "number doubly occupied ci orbitals",
-                "ci root",
-                "print ci details",
-            ):
-                self[key].grid(row=row, column=0, columnspan=2, sticky=tk.EW)
-                widgets.append(self[key])
-                row += 1
 
         self["COSMO"].grid(row=row, column=0, columnspan=2, sticky=tk.EW)
         widgets.append(self["COSMO"])
@@ -187,7 +187,7 @@ class TkEnergy(seamm.TkNode):
                 row += 1
             sw.align_labels(widgets1, sticky=tk.E)
 
-        for key in ("bond orders",):
+        for key in ("calculate gradients", "bond orders"):
             self[key].grid(row=row, column=0, columnspan=2, sticky=tk.EW)
             widgets.append(self[key])
             row += 1


### PR DESCRIPTION
* Calculations using PM7-TS do not write information to the AUX file, so added code to get the energy from the output file.
* For optimizations, the option for the frequency of calculating the force constants and the maximum radius of convergence were missing from the GUI for the EF method. The frequency also was not being correctly handled in the input to MOPAC.
* The GUI for using CI calculations was cleaned up.