### PR TITLE
Bugfix: error if used in a loop and previous directories deleted.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.10.15 -- Bugfix: error if used in a loop and previous directories deleted.
+   * The code crashed if called with a loop in the flowchart, and the last directory of
+     a previous loop iteration was deleted before running the next iteration.
+     
 2024.8.21 -- Bugfix for PM7-TS and optimization, GUI clean up for CI calculations.
   * Calculations using PM7-TS do not write information to the AUX file, so added code to
     get the energy from the output file.

--- a/mopac_step/mopac.py
+++ b/mopac_step/mopac.py
@@ -98,6 +98,8 @@ class MOPAC(mopac_step.MOPACBase):
         directory = Path(self.directory)
         directory.mkdir(parents=True, exist_ok=True)
 
+        next_node = super().run(printer)
+
         system, configuration = self.get_system_configuration(None)
         n_atoms = configuration.n_atoms
         if n_atoms == 0:
@@ -177,8 +179,6 @@ class MOPAC(mopac_step.MOPACBase):
 
         # Work through the subflowchart to find out what to do.
         self.subflowchart.root_directory = self.flowchart.root_directory
-
-        next_node = super().run(printer)
 
         # Get the first real node
         node = self.subflowchart.get_node("1").next()


### PR DESCRIPTION
* The code crashed if called with a loop in the flowchart, and the last directory of a previous loop iteration was deleted before running the next iteration.