### PR TITLE
Fixed an issue with periodic systems and lattice size

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 =======
 History
 =======
+2025.12.21 -- Fixed an issue with periodic systems and lattice size
+    * Mopac is sensitive to where the atoms are in periodic systems, and stops with a
+      warning if the atoms are too far out of the unit cell. SEAMM now avoids this by
+      translating the atoms into the unit cell before running MOPAC.
+    * Added error checking for a bond matrix with incompatible size to the number of
+      atoms and print a warning but continue.
+    * For periodic systems, avoid calculating the RMS and maximum displacement of atoms,
+      which is not well-defined and also causes problems in the current code.
+
 2025.12.20 -- Added control over cell optimization for periodic systems
     * Added control over whether to shear the cell when optimizing, and also to couple
       the diagonal directions so they have identical values.

--- a/mopac_step/energy.py
+++ b/mopac_step/energy.py
@@ -1256,6 +1256,21 @@ class Energy(seamm.Node):
         if n_atoms == 1:
             return "\n\n        No bonds, since there is only one atom.\n"
 
+        # Check dimensions
+        if len(bond_order_matrix) != n_atoms * (n_atoms + 1) / 2:
+            result = (
+                "\n\n        The was an error in the size of the bond order matrix:"
+            )
+            result += f"\n             n_atoms = {n_atoms}"
+            result += (
+                f"\n             size of bond order matrix = {len(bond_order_matrix)}"
+            )
+            result += (
+                f"\n             n_atoms * (n_atoms + 1) / 2 = {n_atoms*(n_atoms+1)/2}"
+            )
+            result += "\n"
+            return result
+
         bond_i = []
         bond_j = []
         bond_order = []

--- a/mopac_step/mopac_base.py
+++ b/mopac_step/mopac_base.py
@@ -101,7 +101,7 @@ class MOPACBase(seamm.Node):
         structure = ""
         atoms = configuration.atoms
         elements = atoms.symbols
-        coordinates = atoms.get_coordinates(fractionals=False)
+        coordinates = atoms.get_coordinates(fractionals=False, in_cell=True)
         if "freeze" in atoms:
             freeze = atoms["freeze"]
         else:

--- a/mopac_step/optimization.py
+++ b/mopac_step/optimization.py
@@ -395,7 +395,8 @@ class Optimization(mopac_step.Energy):
         # Update the structure
         periodicity = initial_configuration.periodicity
         if "ATOM_X_OPT" in data or "ATOM_X_UPDATED" in data:
-            initial_RDKMol = initial_configuration.to_RDKMol()
+            if periodicity == 0:
+                initial_RDKMol = initial_configuration.to_RDKMol()
 
             if P["structure handling"] == "Discard the structure":
                 system = initial_configuration
@@ -446,25 +447,28 @@ class Optimization(mopac_step.Energy):
                 )
 
             if P["structure handling"] == "Discard the structure":
-                RDKMol = initial_configuration.to_RDKMol()
-                RDKMol.GetConformer(0).SetPositions(np.array(xyz))
+                if periodicity == 0:
+                    RDKMol = initial_configuration.to_RDKMol()
+                    RDKMol.GetConformer(0).SetPositions(np.array(xyz))
             else:
                 configuration.atoms.set_coordinates(xyz, fractionals=False)
-                RDKMol = configuration.to_RDKMol()
+                if periodicity == 0:
+                    RDKMol = configuration.to_RDKMol()
 
-            result = RMSD(RDKMol, initial_RDKMol, symmetry=True, include_h=True)
-            data["RMSD with H"] = result["RMSD"]
-            data["displaced atom with H"] = result["displaced atom"]
-            data["maximum displacement with H"] = result["maximum displacement"]
+            if periodicity == 0:
+                result = RMSD(RDKMol, initial_RDKMol, symmetry=True, include_h=True)
+                data["RMSD with H"] = result["RMSD"]
+                data["displaced atom with H"] = result["displaced atom"]
+                data["maximum displacement with H"] = result["maximum displacement"]
 
-            # Align the structure
-            if P["structure handling"] != "Discard the structure":
-                configuration.coordinates_from_RDKMol(RDKMol)
+                # Align the structure
+                if P["structure handling"] != "Discard the structure":
+                    configuration.coordinates_from_RDKMol(RDKMol)
 
-            result = RMSD(RDKMol, initial_RDKMol, symmetry=True)
-            data["RMSD"] = result["RMSD"]
-            data["displaced atom"] = result["displaced atom"]
-            data["maximum displacement"] = result["maximum displacement"]
+                result = RMSD(RDKMol, initial_RDKMol, symmetry=True)
+                data["RMSD"] = result["RMSD"]
+                data["displaced atom"] = result["displaced atom"]
+                data["maximum displacement"] = result["maximum displacement"]
 
             text += seamm.standard_parameters.set_names(
                 system, configuration, P, _first=True, Hamiltonian=P["hamiltonian"]


### PR DESCRIPTION
* Mopac is sensitive to where the atoms are in periodic systems, and stops with a warning if the atoms are too far out of the unit cell. SEAMM now avoids this by translating the atoms into the unit cell before running MOPAC.
* Added error checking for a bond matrix with incompatible size to the number of atoms and print a warning but continue.
* For periodic systems, avoid calculating the RMS and maximum displacement of atoms, which is not well-defined and also causes problems in the current code.