### PR TITLE
2026-06-22 campaign changes:

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,25 @@ extensions = [
     'sphinx_design',
     'sphinx_copybutton',
     'sphinx.ext.todo',
+    'sphinx.ext.intersphinx',
 ]
+
+# The local inventory path lets a local `make html` resolve campaign-doc
+# labels immediately, without needing the main site already pushed live --
+# useful right after writing a brand-new campaign entry, like today's.
+# Falls back to fetching the published inventory over the network if the
+# environment variable isn't set (true for CI and for any other
+# contributor's machine, where this local path wouldn't exist anyway).
+#
+# Set this locally before building docs, e.g.:
+#   export SEAMM_DOCS_OBJECTS_INV=/Users/psaxe/Work/SEAMM/molssi-seamm.github.io/docs/_build/html/objects.inv
+
+intersphinx_mapping = {
+    "seamm": (
+        "https://molssi-seamm.github.io/",
+        os.environ.get("SEAMM_DOCS_OBJECTS_INV"),
+    ),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/developer_guide/campaigns/2026-06-22/NOTES_mopac_model_chemistry_metadata.rst
+++ b/docs/developer_guide/campaigns/2026-06-22/NOTES_mopac_model_chemistry_metadata.rst
@@ -1,0 +1,168 @@
+.. _notes-mopac-model-chemistry-metadata:
+
+================================================================================
+Notes: MOPAC Metadata for the Model Chemistry Step (get_model_chemistry_options)
+================================================================================
+
+:Date: 2026-06-22
+:Status: Classmethod drafted and corrected; metadata for AM1/RM1/PM3/
+   MNDO/MNDOD added; PM6/PM7 element coverage corrected against real
+   source; Sparkle/lanthanide distinction discovered and documented;
+   tests written and dry-run against the real combined data. Not yet
+   applied to the live ``mopac_step`` repository -- these are patches
+   to merge, not a description of completed work in the codebase.
+:Connects to: the Model Chemistry Step campaign, documented in this
+   project's notes as :ref:`plan-model-chemistry-step` (drafted
+   2026-06-20) and, per Paul, also published in the campaigns section
+   of the molssi-seamm.github.io developer guide under today's date.
+   This note was written without direct access to that rendered build
+   (a local file path, not reachable from here) -- the connection
+   below is drawn from this project's own copy of the plan, not from
+   re-reading the published version.
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+
+How this fits into the campaign
+==================================
+
+:ref:`plan-model-chemistry-step` laid out a metadata protocol --
+``get_model_chemistry_options(periodic_only, mdi_only)`` -- that every
+program-step package implementing model chemistries would expose, so
+the (still to be built) Model Chemistry Step's dialog and
+``lammps_step``'s MDI launch logic could both query "what can this
+program provide" uniformly. The plan included a worked sketch of this
+classmethod for MOPAC, built against ``mopac_step``'s real
+``metadata["computational models"]`` structure as it existed at the
+time -- ten parameterizations (PM7, PM7-TS, PM6, PM6-ORG, and the six
+PM6 dispersion/H-bond correction variants), with the explicit
+observation that AM1 and RM1 were absent from that structure entirely,
+not just unconfirmed for periodicity.
+
+This note documents closing that gap and the corrections that followed
+from doing so properly rather than guessing -- this is Phase 2 of the
+plan's phased breakdown ("confirm the AM1/RM1 periodic flags ... land
+the classmethod for real"), plus some unplanned but necessary detours
+once real source data was available to check against.
+
+
+What was done, in order
+==========================
+
+1. Drafted ``MOPACStep.get_model_chemistry_options()`` against the
+   metadata structure as it stood, with ``_MDI_CAPABLE_METHODS`` (the
+   six methods in ``mopactools.api.MopacSystem.model_dict``) and
+   ``_MDI_PERIODIC_VALIDATED`` (the three -- PM7, PM6-ORG, PM6 --
+   actually run periodic via MDI and confirmed this week, per
+   :ref:`notes-qm-mdi-engines-validation`) as class attributes.
+2. Corrected the class name used in the draft (``MOPACStep``, not
+   ``MopacStep`` as first guessed) and the import style
+   (``mopac_step.metadata``, matching the file's own existing
+   convention) against the real uploaded ``mopac_step`` bundle.
+3. Drafted metadata entries for AM1, RM1, PM3, MNDO, and MNDOD,
+   initially from general knowledge -- explicitly flagged at the time
+   as unverified, since none of it had been checked against any real
+   source.
+4. Given MOPAC's actual parameter source files (``src/models/
+   parameters_for_*_C.F90``), re-extracted real element coverage for
+   all five by parsing each file's "Data for Element" header comments
+   and excluding non-element pseudo-atom entries (MOPAC's "Capped
+   bond" dummy atoms). This changed every one of the five from
+   guessed to verified, and incidentally revealed that RM1's parameter
+   table includes the full lanthanide series (La-Lu) -- unexpected,
+   not predicted from general knowledge of the original 2006 RM1
+   paper's 10-element scope.
+5. At Paul's request, applied the same direct-extraction technique to
+   the *existing*, previously-unquestioned PM6/PM7 entries (elements
+   "1-60,62-83"). This is where the real correction landed: actual
+   coverage is "1-57,71-83,85,87,90,97" -- the old value understated
+   the lanthanide gap by an order of magnitude (one element, Pm,
+   thought missing; thirteen, Ce-Yb, actually missing). Also surfaced
+   a parameter table entry at Z=98 labeled "Mithril" in the source
+   comment (Tolkien's fictional metal; Z=98 is actually Californium) --
+   excluded from the verified range pending confirmation of whether
+   this is real, mislabeled Californium data or a non-functional
+   placeholder.
+6. Paul identified the actual explanation for the PM6/PM7 lanthanide
+   gap from ``mopac_step``'s own ``mopac.py``: Ce-Yb are only
+   representable via the SPARKLES point-charge model (no real NDDO
+   parameters exist for them at all), while La and Lu have genuine
+   parameters and may *optionally* use SPARKLES (geometry vs. energy
+   tradeoff). This is a deliberate design choice, not a coverage gap --
+   reclassified accordingly rather than just re-including the
+   lanthanides in the plain "elements" string, which would have erased
+   the real distinction between full electronic treatment and the
+   cruder point-charge approximation.
+7. Added a new ``sparkle_elements`` metadata field (currently
+   documented only for PM7, PM7-TS, PM6) to carry this distinction
+   without conflating it with genuine NDDO coverage. Deliberately did
+   *not* add it to RM1, since RM1's lanthanide parameters are real NDDO
+   data for the full range, not Sparkle-only -- a materially different
+   situation despite both involving the same block of elements.
+8. While drafting tests for the classmethod, caught that the
+   classmethod itself never surfaced ``sparkle_elements`` in its
+   returned dict -- the field was added to raw metadata after the
+   classmethod was first drafted, and nothing had gone back to wire it
+   through. Fixed and re-verified.
+9. Wrote nine tests covering: full enumeration against raw metadata,
+   the MDI-only and periodic-only filters independently and combined,
+   the PM6-D3H4 trap specifically (MDI-capable but not periodic-safe),
+   a non-MDI method's launch info being correctly empty, AM1/RM1
+   appearing now that real entries exist for them, the model-chemistry
+   string format, the sparkle_elements field appearing only where
+   documented, and every option having a non-empty elements string.
+   All nine dry-run successfully against the actual combined metadata
+   and classmethod logic (not just asserted to be correct).
+
+
+Open questions surfaced, not resolved here
+=============================================
+
+* **Whether SPARKLES is reachable via the MDI path at all.**
+  ``mopactools``'s ``MopacSystem`` struct, as reviewed so far, has no
+  free-text keyword field -- only structured attributes (model,
+  charge, spin, atom, coord, lattice). The traditional ``mopac_step``
+  batch path injects ``"SPARKLES"`` as extra keyword text into the
+  ``.mop`` file; no equivalent has been found in the MDI path. If none
+  exists, any system containing La, Lu, or Ce-Yb may be entirely
+  unrunnable via ``mopac_mdi.py``, independent of the ``periodic_mdi``
+  flag. Not resolved -- needs a direct check against the full
+  ``mopactools`` API rather than inference from the parts already
+  reviewed.
+* **Z=98 "Mithril" entry** -- real (mislabeled) data or a non-functional
+  placeholder, not determined.
+* **PM6-ORG and the six PM6 correction variants (D3, DH+, DH2, DH2X,
+  D3H4, D3H4X)** still carry their original, unverified element ranges.
+  ``PM6-ORG``'s own parameter file exists in the bundle already
+  provided and could be checked the same way PM6/PM7 were. The
+  correction variants have no separate parameter file in what's been
+  reviewed -- their core-electronic coverage should match PM6's
+  corrected range, but the correction term itself (dispersion/H-bond
+  coefficients) plausibly covers a narrower subset that nothing
+  reviewed so far actually specifies.
+* None of the above changes ``_MDI_PERIODIC_VALIDATED``. That set
+  remains exactly ``{PM7, PM6-ORG, PM6}`` -- empirical, run-and-checked
+  status, unaffected by any metadata correction in either direction.
+
+
+Files affected (patches drafted, not yet merged)
+====================================================
+
+* ``mopac_step/metadata.py`` -- ``metadata["computational models"]``,
+  extended and corrected as described above.
+* ``mopac_step/mopac_step.py`` -- new ``get_model_chemistry_options()``
+  classmethod plus its two supporting class attributes.
+* ``tests/test_get_model_chemistry_options.py`` -- new test file.
+
+
+References
+==========
+
+* :ref:`plan-model-chemistry-step`
+* :ref:`notes-qm-mdi-engines-validation`
+* MOPAC parameter source: ``src/models/parameters_for_*_C.F90``
+  (uploaded as ``parameters.md``)
+* ``mopac_step/mopac.py``'s SPARKLES handling (the source of the
+  Sparkle/lanthanide explanation in this note)

--- a/docs/developer_guide/campaigns/index.rst
+++ b/docs/developer_guide/campaigns/index.rst
@@ -1,0 +1,11 @@
+Campaigns
+=========
+
+Contents:
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   */NOTES*
+

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -9,3 +9,4 @@ Contents:
    installation
    usage
    contributing
+   campaigns/index

--- a/mopac_step/data/mopac_mdi.py
+++ b/mopac_step/data/mopac_mdi.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+mopac_mdi.py -- MDI engine wrapping MOPAC via the mopactools Python API.
+
+Unlike MOPAC's native Fortran MDI engine, this script needs no .mop input
+file and no MPI-enabled MOPAC build: mopactools loads the plain libmopac
+shared library directly, and all structural information (atom count,
+elements, coordinates, cell) is obtained entirely from the MDI handshake
+with the driver. Charge and spin are supplied via CLI defaults, optionally
+overridden by >TOTCHARGE / >ELEC_MULT if the driver sends them (LAMMPS's
+fix mdi/qm currently does not, as of the version tested this week).
+
+Known issue carried over from MOPAC's native MDI engine, addressed here
+by construction: MOPAC's stress tensor (calculate_voigt(), reached via
+compfg.F90) is only populated when ALL lattice vectors are flagged
+"movable" -- this script always sets nlattice_move = nlattice for exactly
+this reason, mirroring the Tv "+1" workaround used for the native engine.
+Confirmed working empirically via in.mopac_stress_check.
+
+Sign conventions confirmed from the mopactools docstrings and this week's
+native-engine validation:
+    coord_deriv : dE/dx in kcal/(mol*Angstrom) -- force = -coord_deriv
+    stress      : Voigt (xx,yy,zz,yz,xz,xy), GPa, tensile positive
+                  (MOPAC convention) -- negate for MDI/LAMMPS (compressive
+                  positive), exactly as established for the native engine.
+
+MOZYME (--mozyme) is currently unreliable for periodic liquid MD: even
+with --mozyme-restart-every 1 (a fresh Lewis-structure/LMO build every
+single step, no state reuse at all), the bonding-analysis heuristic can
+still occasionally mis-assign a transient hydrogen-bond contact as
+covalent, producing a Lewis structure that doesn't balance to the
+declared total charge ("Unit cell has a charge" / "ERROR DETECTED IN
+SUBROUTINE CHECK"). This is a known open question for the MOPAC
+developers, not something this script can paper over -- use the
+conventional solver (the default, no --mozyme) for periodic liquid MD
+until/unless that's resolved upstream.
+
+Usage -- TCP mode (two terminals, simplest for testing):
+    Terminal 1:
+        python mopac_mdi.py \\
+            -mdi "-role ENGINE -name MOPAC -method TCP -port 8021 \\
+            -hostname localhost" --method PM6-ORG --charge 0 --multiplicity 1
+
+    Terminal 2:
+        mpirun -np 1 lmp -in in.mopac_nvt \\
+            -mdi "-role DRIVER -name LAMMPS -method TCP -port 8021"
+
+No --structure or --elements argument is needed if the LAMMPS fix mdi/qm
+line uses the "elements" keyword (e.g. "elements C O H H") -- LAMMPS then
+sends atomic numbers directly via >ELEMENTS. --elements is only needed as
+a fallback if the driver instead sends LAMMPS atom types via >TYPES.
+
+Dependencies:
+    conda install -c conda-forge mopactools pymdi seamm_util
+    (no MPI requirement on this side when using -method TCP)
+
+Logging: three levels, set via --log-level.
+    DEBUG   -- every MDI command received, plus per-call raw energy/stress
+    INFO    -- lifecycle events, per-call timing, MOZYME restarts (default)
+    WARNING -- only warnings and errors (quietest)
+"""
+
+import argparse
+import logging
+import sys
+import time
+import numpy as np
+
+from seamm_util import Q_
+
+# mpi4py only needed for -method MPI; harmless if unused for TCP.
+try:
+    from mpi4py import MPI  # noqa: F401
+except ImportError:
+    pass
+
+logger = logging.getLogger("mopac-mdi")
+
+# ---------------------------------------------------------------------------
+# Unit conversion factors via seamm_util's Q_ (pint Quantity, pre-configured
+# exactly as the rest of SEAMM uses it -- e.g. gaussian_step, thermomechanical_step
+# both use Q_(value, "hartree").m_as(...)-style calls) rather than a bare
+# pint.UnitRegistry() or hardwired CODATA constants. Computed once at import.
+# ---------------------------------------------------------------------------
+
+ANG_PER_BOHR = Q_(1.0, "bohr").m_as("angstrom")
+BOHR_PER_ANG = Q_(1.0, "angstrom").m_as("bohr")
+HARTREE_PER_KCALMOL = Q_(1.0, "kcal/mol").m_as("hartree")
+GPA_PER_HARTREE_BOHR3 = Q_(1.0, "hartree/bohr**3").m_as("GPa")
+
+
+def multiplicity_to_spin(multiplicity, n_electrons):
+    """
+    Convert a standard multiplicity (2S+1) to mopactools' "excess spin"
+    convention, per the MopacSystem docstring:
+        spin=0 -> singlet (even electrons) or doublet (odd electrons)
+        spin=1 -> triplet (even electrons)
+    The general pattern (spin=N is N steps of multiplicity-by-2 above the
+    minimum state) is an INFERENCE beyond the two cases mopactools
+    documents explicitly. Verified consistent with both documented cases;
+    not independently confirmed beyond spin=0,1. Treat with appropriate
+    caution for higher-spin systems.
+    """
+    minimum_multiplicity = 1 if (n_electrons % 2 == 0) else 2
+    diff = multiplicity - minimum_multiplicity
+    if diff < 0 or diff % 2 != 0:
+        raise ValueError(
+            f"multiplicity {multiplicity} is not reachable for "
+            f"{n_electrons} electrons (minimum multiplicity "
+            f"{minimum_multiplicity}, must differ by an even number)"
+        )
+    return diff // 2
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="MOPAC MDI engine (mopactools API) for LAMMPS fix mdi/qm"
+    )
+    p.add_argument(
+        "-mdi",
+        required=True,
+        help="MDI initialization string passed directly to MDI_Init",
+    )
+    # Must match _MDI_CAPABLE_METHODS in mopac_step.py
+    p.add_argument(
+        "--method",
+        default="PM7",
+        choices=["PM7", "PM6-D3H4", "PM6-ORG", "PM6", "AM1", "RM1"],
+        help="MOPAC semiempirical model (default: PM7)",
+    )
+    p.add_argument(
+        "--charge",
+        type=int,
+        default=0,
+        help="Total charge of the system (default: 0). "
+        "Overridden if the driver sends >TOTCHARGE.",
+    )
+    p.add_argument(
+        "--multiplicity",
+        type=int,
+        default=1,
+        help="Standard spin multiplicity, 2S+1 (default: 1, singlet). "
+        'Converted internally to mopactools\' "excess spin" convention. '
+        "Overridden if the driver sends >ELEC_MULT.",
+    )
+    p.add_argument(
+        "--elements",
+        nargs="+",
+        metavar="SYM",
+        default=None,
+        help="Element symbol for each LAMMPS atom type, in order "
+        "(e.g. --elements C O H H). Only used as a fallback if the "
+        "driver sends >TYPES instead of >ELEMENTS (i.e. if the LAMMPS "
+        'fix mdi/qm line omits the "elements" keyword).',
+    )
+    p.add_argument(
+        "--mozyme",
+        action="store_true",
+        help="Use the linear-scaling MOZYME solver instead of the "
+        "conventional solver (closed-shell systems only). Currently "
+        "unreliable for periodic liquid MD -- see module docstring.",
+    )
+    p.add_argument(
+        "--mozyme-restart-every",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Only relevant with --mozyme. MOPAC's manual documents that "
+        "LMO orthonormality degrades gradually when many SCF "
+        "calculations are chained together (harmless for one SCF, "
+        "cumulative otherwise) -- exactly the situation in an MD run "
+        "where the same MozymeState persists across thousands of "
+        "steps. Every N calculations, this script discards the "
+        "persistent state and builds a fresh MozymeState, forcing "
+        "MOPAC to redo its Lewis-structure bonding analysis and "
+        "LMO localization from the current geometry rather than "
+        "drifting indefinitely. Default of 10 is a placeholder, not "
+        "yet confirmed against MOPAC-developer guidance on a safe "
+        "interval -- treat as provisional. (default: 10)",
+    )
+    p.add_argument(
+        "--tolerance",
+        type=float,
+        default=1.0,
+        help="Relative SCF convergence tolerance, mopactools default=1.0 "
+        "(default: 1.0)",
+    )
+    p.add_argument(
+        "--max-time",
+        type=int,
+        default=600,
+        help="Per-call wall-time limit in seconds (default: 600). "
+        "mopactools' own default is 3600; reduced here so a single "
+        "stuck MD step does not hang for an hour. Increase for very "
+        "large systems if legitimate calculations are being cut off.",
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="DEBUG: every MDI command plus raw energy/stress each call. "
+        "INFO: lifecycle events, per-call timing, MOZYME restarts "
+        "(default). WARNING: only warnings and errors (quietest).",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(levelname)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+    try:
+        import mdi
+    except ImportError:
+        logger.error("mdi not found. conda install -c conda-forge pymdi")
+        sys.exit(1)
+    try:
+        from mopactools.api import MopacSystem, MopacState, MozymeState, from_data
+    except ImportError:
+        logger.error("mopactools not found. conda install -c conda-forge mopactools")
+        sys.exit(1)
+
+    # Optional --elements fallback map (LAMMPS type index -> atomic number),
+    # only used if the driver sends >TYPES instead of >ELEMENTS.
+    type_to_z = None
+    if args.elements is not None:
+        type_to_z = {
+            i + 1: MopacSystem.periodic_table[sym]
+            for i, sym in enumerate(args.elements)
+        }
+
+    # ----------------------------------------------------------------
+    # MDI initialisation and command registration
+    # ----------------------------------------------------------------
+    mdi.MDI_Init(args.mdi)
+    comm = mdi.MDI_Accept_Communicator()
+
+    mdi.MDI_Register_node("@DEFAULT")
+    for _cmd in [
+        "<NATOMS",
+        ">NATOMS",
+        "<NAME",
+        ">ELEMENTS",
+        ">TYPES",
+        ">COORDS",
+        ">CELL",
+        ">TOTCHARGE",
+        ">ELEC_MULT",
+        "SCF",
+        "<ENERGY",
+        "<FORCES",
+        "<STRESS",
+        "EXIT",
+    ]:
+        mdi.MDI_Register_command("@DEFAULT", _cmd)
+
+    logger.info(f"MDI connection established. method={args.method}")
+
+    # ----------------------------------------------------------------
+    # State accumulated from the MDI handshake -- no input file at all.
+    # ----------------------------------------------------------------
+    natoms = None
+    atomic_numbers = None
+    coords_bohr = None
+    cell_flat = None
+    is_periodic = False
+
+    charge = args.charge
+    raw_multiplicity = args.multiplicity  # may be overridden by >ELEC_MULT
+
+    system = None
+    state = None
+    properties = None
+    have_elements = False
+    have_coords = False
+    recompute = True
+    mozyme_step_count = 0  # calculations since the last MozymeState rebuild
+
+    def build_system():
+        """Construct the MopacSystem (once) now that natoms/elements/coords
+        (and cell, if periodic) are known. nlattice_move is always set
+        equal to nlattice -- see module docstring."""
+        nonlocal system, state, mozyme_step_count
+
+        n_electrons = int(np.sum(atomic_numbers)) - charge
+        spin = multiplicity_to_spin(raw_multiplicity, n_electrons)
+
+        if args.mozyme and spin != 0:
+            logger.warning(
+                "--mozyme requested with a non-closed-shell multiplicity; "
+                "MozymeState has no spin/uhf field, MOZYME assumes "
+                "closed-shell."
+            )
+
+        sys_obj = MopacSystem()
+        sys_obj.natom = natoms
+        sys_obj.natom_move = natoms  # all atoms movable: full gradient
+        sys_obj.charge = charge
+        sys_obj.spin = spin
+        sys_obj.model = args.method
+        sys_obj.epsilon = 1.0  # vacuum; explicit solvent, no implicit model
+        sys_obj.atom = atomic_numbers.astype(np.int32)
+        sys_obj.coord = (coords_bohr.reshape(-1, 3) * ANG_PER_BOHR).ravel()
+        if is_periodic:
+            sys_obj.nlattice = 3
+            sys_obj.nlattice_move = 3  # ALWAYS all-movable: stress workaround
+            sys_obj.lattice = (cell_flat.reshape(3, 3) * ANG_PER_BOHR).ravel()
+        else:
+            sys_obj.nlattice = 0
+            sys_obj.nlattice_move = 0
+            sys_obj.lattice = np.array([], dtype=np.float64)
+        sys_obj.pressure = 0.0  # only relevant to mopac_relax
+        sys_obj.tolerance = args.tolerance
+        sys_obj.max_time = args.max_time
+
+        if args.mozyme:
+            st_obj = MozymeState()
+        else:
+            st_obj = MopacState()
+            st_obj.uhf = spin != 0
+
+        system = sys_obj
+        state = st_obj
+        mozyme_step_count = 0
+        logger.info(
+            f"System built: natoms={natoms}, periodic={is_periodic}, "
+            f"charge={charge}, multiplicity={raw_multiplicity} "
+            f"(spin={spin}), mozyme={args.mozyme}"
+        )
+
+    def maybe_restart_mozyme():
+        """Every --mozyme-restart-every calculations, discard the
+        persistent MozymeState and build a fresh one, forcing MOPAC to
+        redo Lewis-structure bonding analysis and LMO localization from
+        the current geometry rather than letting orthonormality drift
+        indefinitely across thousands of MD steps. See the
+        --mozyme-restart-every help text and MOPAC's MOZYME manual page."""
+        nonlocal state
+        if (
+            args.mozyme
+            and mozyme_step_count > 0
+            and mozyme_step_count % args.mozyme_restart_every == 0
+        ):
+            logger.info(
+                f"MOZYME restart (count={mozyme_step_count}): "
+                f"rebuilding LMOs from current geometry"
+            )
+            state = MozymeState()
+
+    def update_geometry():
+        """Push the latest coordinates/cell into the existing system
+        object. Called every step once the system has been built."""
+        system.coord = (coords_bohr.reshape(-1, 3) * ANG_PER_BOHR).ravel()
+        if is_periodic:
+            system.lattice = (cell_flat.reshape(3, 3) * ANG_PER_BOHR).ravel()
+
+    def run_calculation():
+        """Run mopac_scf/mozyme_scf (dispatched by from_data based on the
+        state type) and check for reported errors."""
+        nonlocal properties
+        mpack_before = getattr(state, "mpack", None)
+        t0 = time.perf_counter()
+        properties = from_data(system, state, relax=False, vibe=False)
+        elapsed = time.perf_counter() - t0
+        mpack_after = getattr(state, "mpack", None)
+        logger.info(
+            f"from_data() took {elapsed:.3f} s "
+            f"(state.mpack: {mpack_before} -> {mpack_after})"
+        )
+        if properties.error_msg:
+            raise RuntimeError(
+                "MOPAC reported error(s): " + "; ".join(properties.error_msg)
+            )
+        logger.debug(
+            f"heat = {properties.heat:.8f} kcal/mol "
+            f"({properties.heat * HARTREE_PER_KCALMOL:.8f} Ha)"
+        )
+        if is_periodic and properties.stress is not None:
+            logger.debug(f"stress (raw, GPa, Voigt): {properties.stress}")
+
+    # ----------------------------------------------------------------
+    # MDI event loop
+    # ----------------------------------------------------------------
+    logger.info("Entering MDI event loop ...")
+
+    while True:
+        command = mdi.MDI_Recv_Command(comm)
+        logger.debug(f"command: {command!r}")
+
+        # ---- Metadata -------------------------------------------------
+        if command == "<NATOMS":
+            mdi.MDI_Send(natoms, 1, mdi.MDI_INT, comm)
+
+        elif command == ">NATOMS":
+            raw = mdi.MDI_Recv(1, mdi.MDI_INT, comm)
+            natoms = int(np.asarray(raw).flat[0])
+            atomic_numbers = np.zeros(natoms, dtype=int)
+            coords_bohr = np.zeros(3 * natoms)
+            logger.debug(f">NATOMS: {natoms}")
+
+        elif command == "<NAME":
+            mdi.MDI_Send("MOPAC", mdi.MDI_NAME_LENGTH, mdi.MDI_CHAR, comm)
+
+        # ---- Structural data from the driver ---------------------------
+        elif command == ">ELEMENTS":
+            # Preferred path: driver sends atomic numbers directly.
+            raw = mdi.MDI_Recv(natoms, mdi.MDI_INT, comm)
+            atomic_numbers[:] = np.asarray(raw)
+            have_elements = True
+            recompute = True
+
+        elif command == ">TYPES":
+            # Fallback path: driver sends LAMMPS atom types; need --elements
+            # to map type -> atomic number ourselves.
+            if type_to_z is None:
+                raise RuntimeError(
+                    ">TYPES received but no --elements mapping was given. "
+                    "Either add 'elements <syms>' to the LAMMPS fix mdi/qm "
+                    "line (sends >ELEMENTS instead), or pass --elements here."
+                )
+            raw = mdi.MDI_Recv(natoms, mdi.MDI_INT, comm)
+            types = np.asarray(raw)
+            atomic_numbers[:] = [type_to_z[t] for t in types]
+            have_elements = True
+            recompute = True
+
+        elif command == ">COORDS":
+            raw = mdi.MDI_Recv(3 * natoms, mdi.MDI_DOUBLE, comm)
+            coords_bohr[:] = np.asarray(raw)
+            have_coords = True
+            recompute = True
+
+        elif command == ">CELL":
+            raw = mdi.MDI_Recv(9, mdi.MDI_DOUBLE, comm)
+            cell_flat = np.asarray(raw)
+            is_periodic = True
+            recompute = True
+
+        # ---- Optional driver-supplied charge/multiplicity --------------
+        elif command == ">TOTCHARGE":
+            raw = mdi.MDI_Recv(1, mdi.MDI_DOUBLE, comm)
+            charge = int(round(float(np.asarray(raw).flat[0])))
+            system = None  # force rebuild with new charge
+            recompute = True
+
+        elif command == ">ELEC_MULT":
+            raw = mdi.MDI_Recv(1, mdi.MDI_INT, comm)
+            raw_multiplicity = int(np.asarray(raw).flat[0])
+            system = None  # force rebuild with new multiplicity
+            recompute = True
+
+        # ---- Calculation trigger / lazy evaluation ---------------------
+        elif command in ("SCF", "<ENERGY", "<FORCES", "<STRESS"):
+            if recompute or system is None:
+                if not (have_elements and have_coords):
+                    raise RuntimeError(
+                        f"{command} requested before elements/coords were "
+                        f"received via MDI -- check the driver sends "
+                        f">ELEMENTS (or >TYPES) and >COORDS before "
+                        f"requesting properties."
+                    )
+                if system is None:
+                    build_system()
+                else:
+                    maybe_restart_mozyme()
+                    update_geometry()
+                run_calculation()
+                mozyme_step_count += 1
+                recompute = False
+
+            # Property responses (no-op for plain "SCF")
+            if command == "<ENERGY":
+                mdi.MDI_Send(
+                    properties.heat * HARTREE_PER_KCALMOL, 1, mdi.MDI_DOUBLE, comm
+                )
+
+            elif command == "<FORCES":
+                # coord_deriv = dE/dx [kcal/(mol*Ang)]; force = -dE/dx
+                grad_kcal_ang = properties.coord_deriv.reshape(-1, 3)
+                grad_ha_bohr = (grad_kcal_ang * HARTREE_PER_KCALMOL) * BOHR_PER_ANG
+                forces = -grad_ha_bohr.ravel()
+                mdi.MDI_Send(forces, 3 * natoms, mdi.MDI_DOUBLE, comm)
+
+            elif command == "<STRESS":
+                if not is_periodic:
+                    raise RuntimeError("<STRESS requested for a non-periodic system")
+                voigt = properties.stress  # GPa, Voigt (xx,yy,zz,yz,xz,xy), tensile+
+                # Voigt -> full 3x3 tensor (symmetric placement)
+                full = np.array(
+                    [
+                        [voigt[0], voigt[5], voigt[4]],
+                        [voigt[5], voigt[1], voigt[3]],
+                        [voigt[4], voigt[3], voigt[2]],
+                    ]
+                )
+                # Negate (tensile+ -> compressive+) and convert GPa -> Ha/Bohr^3
+                stress_ha_bohr3 = -full / GPA_PER_HARTREE_BOHR3
+                mdi.MDI_Send(stress_ha_bohr3.ravel(), 9, mdi.MDI_DOUBLE, comm)
+
+        # ---- Shutdown ---------------------------------------------------
+        elif command == "EXIT":
+            logger.info("EXIT -- shutting down.")
+            break
+
+        else:
+            logger.warning(f"unrecognised command {command!r}")
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mopac_step/data/seamm-mopac.yml
+++ b/mopac_step/data/seamm-mopac.yml
@@ -2,5 +2,9 @@ name: seamm-mopac
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python=3.12
   - mopac
+  - mopactools
+  - numpy
+  - pymdi
+  - seamm-util

--- a/mopac_step/metadata.py
+++ b/mopac_step/metadata.py
@@ -14,14 +14,41 @@ metadata["computational models"] = {
             "PM7": {
                 "parameterizations": {
                     "PM7": {
-                        "elements": "1-60,62-83",
+                        # CORRECTED 2026-06-21 against parameters_for_PM7_C.F90,
+                        # then re-interpreted 2026-06-22 per mopac.py's own
+                        # SPARKLES logic: Ce-Yb (58-70) are genuinely absent
+                        # from the NDDO parameter table because they are
+                        # ONLY representable via the Sparkle point-charge
+                        # model, not full electronic structure -- this is a
+                        # deliberate design choice, not a coverage gap.
+                        # La(57)/Lu(71) have real NDDO parameters AND may
+                        # optionally use SPARKLES (better geometry vs.
+                        # better energy, per mopac.py's comment). "elements"
+                        # below is genuine NDDO Hamiltonian coverage only;
+                        # see "sparkle_elements" for the Sparkle-only set.
+                        # Z=98 ("Mithril" in the source comment -- real
+                        # Californium data or a non-functional placeholder,
+                        # not resolved) remains excluded pending verification.
+                        #
+                        # OPEN QUESTION, not resolved here: mopactools'
+                        # MopacSystem struct (used by mopac_mdi.py) has no
+                        # free-text keyword field -- unclear whether SPARKLES
+                        # is reachable via the MDI path at all. If not, any
+                        # system containing La/Lu/Ce-Yb may be unrunnable via
+                        # mopac_mdi.py regardless of the periodic_mdi flag.
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",  # La-Lu; 58-70 mandatory,
+                        # 57/71 optional
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
                         "code": "mopac",
                     },
                     "PM7-TS": {
-                        "elements": "1-60,62-83",
+                        # Same core Hamiltonian and Sparkle situation as PM7
+                        # above.
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": False,
@@ -32,14 +59,18 @@ metadata["computational models"] = {
             "PM6": {
                 "parameterizations": {
                     "PM6": {
-                        "elements": "1-60,62-83",
+                        # Same correction and Sparkle situation as PM7 above
+                        # -- both files show an identical coverage pattern.
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
                         "code": "mopac",
                     },
                     "PM6-ORG": {
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
@@ -50,7 +81,8 @@ metadata["computational models"] = {
                             "The PM6 Hamiltonian with Grimme's corrections for "
                             "dispersion"
                         ),
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
@@ -61,7 +93,8 @@ metadata["computational models"] = {
                             "The PM6 Hamiltonian with corrections for dispersion "
                             "and hydrogen-bonding"
                         ),
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
@@ -72,7 +105,8 @@ metadata["computational models"] = {
                             "The PM6 Hamiltonian with corrections for dispersion "
                             "and hydrogen-bonding"
                         ),
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
@@ -83,7 +117,8 @@ metadata["computational models"] = {
                             "The PM6 Hamiltonian with corrections for dispersion "
                             "and hydrogen- and halogen-bonding"
                         ),
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": True,
                         "reactions": True,
                         "optimization": True,
@@ -102,7 +137,8 @@ metadata["computational models"] = {
                             "small. For details, see: European Journal of Medicinal "
                             "Chemistry 2015, 89, 189-197."
                         ),
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": False,
                         "reactions": True,
                         "optimization": True,
@@ -115,10 +151,114 @@ metadata["computational models"] = {
                             "halogen-oxygen and halogen-nitrogen interactions to the "
                             "D3H4 model."
                         ),
-                        "elements": "1-60,62-83",
+                        "elements": "1-57,71-83,85,87,90,97",
+                        "sparkle_elements": "57-71",
                         "periodic": False,
                         "reactions": True,
                         "optimization": True,
+                        "code": "mopac",
+                    },
+                }
+            },
+            # --- New below this line: AM1/RM1, PM3, MNDO/MNDOD -----------
+            # Added 2026-06-20, elements corrected 2026-06-21 against the
+            # actual MOPAC parameter source (src/models/parameters_for_*_C.F90,
+            # uploaded as parameters.md) -- element lists below are extracted
+            # directly from each file's "Data for Element N: Name" headers,
+            # with pseudo-atom entries (Capped bond, Sparkle) excluded.
+            # periodic/reactions/optimization are NOT determinable from these
+            # parameter files (they describe algorithmic support, not fitted
+            # constants) and remain INFERRED, unverified general knowledge.
+            # None of these five are in MOPACStep._MDI_PERIODIC_VALIDATED
+            # regardless of the "periodic" flag set here -- that set only
+            # grows when a method is actually run periodic via MDI and
+            # confirmed. See NOTES_qm_mdi_engines_validation.rst /
+            # PLAN_model_chemistry_step.rst.
+            "AM1": {
+                "parameterizations": {
+                    "AM1": {
+                        # VERIFIED against parameters_for_AM1_C.F90.
+                        "elements": "1-20,30-38,42,49-56,80-83",
+                        "periodic": True,  # INFERRED, not confirmed
+                        "reactions": True,  # INFERRED
+                        "optimization": True,  # INFERRED
+                        "code": "mopac",
+                    },
+                    "RM1": {
+                        "description": (
+                            "Rocha, Freire, Simas, and Stewart's 2006 "
+                            "reparameterization of AM1, originally fit to "
+                            "H, C, N, O, F, P, S, Cl, Br, I. This MOPAC "
+                            "build's parameter table also includes the full "
+                            "lanthanide series (La-Lu) -- provenance of that "
+                            "extension (separate publication vs. otherwise) "
+                            "not confirmed here."
+                        ),
+                        # VERIFIED against parameters_for_RM1_C.F90. Original
+                        # 10-element set confirmed exactly; lanthanide
+                        # coverage (57-71) is real but unexpected -- see
+                        # description.
+                        "elements": "1,6-9,15-17,35,53,57-71",
+                        "periodic": True,  # INFERRED
+                        "reactions": True,  # INFERRED
+                        "optimization": True,  # INFERRED
+                        "code": "mopac",
+                    },
+                }
+            },
+            "PM3": {
+                "parameterizations": {
+                    "PM3": {
+                        "description": (
+                            "Stewart's 1989 reparameterization of the "
+                            "MNDO/AM1 NDDO formalism. Element coverage was "
+                            "originally built up across four separate papers "
+                            "(Stewart_1989, Stewart_1991, Anders_1993, "
+                            "Stewart_2004) -- see mopac_step's own citation "
+                            "logic for the per-paper breakdown."
+                        ),
+                        # VERIFIED against parameters_for_PM3_C.F90 (combined
+                        # coverage across all four papers' contributions).
+                        "elements": "1-20,30-38,48-56,80-83,87",
+                        "periodic": True,  # INFERRED
+                        "reactions": True,  # INFERRED
+                        "optimization": True,  # INFERRED
+                        "code": "mopac",
+                    },
+                }
+            },
+            "MNDO": {
+                "parameterizations": {
+                    "MNDO": {
+                        "description": (
+                            "Dewar and Thiel's 1977 original NDDO " "Hamiltonian."
+                        ),
+                        # VERIFIED against parameters_for_mndo_C.F90.
+                        # Manganese (25) is genuinely absent -- not an
+                        # extraction error, confirmed by the gap between
+                        # Chromium (24) and Iron (26) in the source.
+                        "elements": "1-24,26-38,40,42,46-56,78,80-83,85,87,90",
+                        "periodic": True,  # INFERRED
+                        "reactions": True,  # INFERRED
+                        "optimization": True,  # INFERRED
+                        "code": "mopac",
+                    },
+                    "MNDOD": {
+                        "description": (
+                            "Thiel and Voityuk's d-orbital extension of "
+                            "MNDO, for hypervalent compounds and heavier "
+                            "main-group/transition elements."
+                        ),
+                        # VERIFIED against parameters_for_mndod_C.F90. This
+                        # file's own coverage (the d-orbital extension itself)
+                        # is narrower than base MNDO above -- whether a
+                        # MNDOD calculation also draws on plain MNDO
+                        # parameters for elements outside this list is not
+                        # resolved here.
+                        "elements": "1-17,30,35,48,53,80",
+                        "periodic": True,  # INFERRED
+                        "reactions": True,  # INFERRED
+                        "optimization": True,  # INFERRED
                         "code": "mopac",
                     },
                 }

--- a/mopac_step/mopac_step.py
+++ b/mopac_step/mopac_step.py
@@ -1,3 +1,4 @@
+# mopac_step/mopac_step.py
 # -*- coding: utf-8 -*-
 
 """Main module."""
@@ -30,3 +31,98 @@ class MOPACStep(object):
     def create_tk_node(self, canvas=None, **kwargs):
         """Return the graphical Tk node object"""
         return mopac_step.TkMOPAC(canvas=canvas, **kwargs)
+
+    # Patch to mopac_step/mopac_step.py -- add to the MOPACStep class,
+    # alongside description()/create_node()/create_tk_node().
+    #
+    # Revision 2026-06-22: now surfaces "sparkle_elements" in the returned
+    # dict (added to the raw metadata for PM7/PM7-TS/PM6ants on 2026-06-22, but
+    # the first draft of this classmethod predated that field and never
+    # passed it through -- caught while writing tests, fixed here).
+
+    # mopactools.api.MopacSystem.model_dict's scope -- see mopac_mdi.py's
+    # --method choices. This is the authoritative source for what's
+    # actually reachable via MDI; update here if mopactools changes.
+
+    _MDI_CAPABLE_METHODS = {"PM7", "PM6-D3H4", "PM6-ORG", "PM6", "AM1", "RM1"}
+
+    # Methods actually run periodic via MDI and confirmed working, per
+    # NOTES_qm_mdi_engines_validation.rst. Cross-checked against the real
+    # metadata["computational models"] entries -- PM7, PM6, and PM6-ORG are
+    # the only three with both periodic=True there AND an actual validated
+    # periodic MDI run this week. PM6-D3H4 is MDI-capable but deliberately
+    # excluded: its own metadata entry says periodic=False, and MOPAC's
+    # documentation confirms D3H4 does not work under periodic boundary
+    # conditions at all.
+
+    _MDI_PERIODIC_VALIDATED = {"PM7", "PM6-ORG", "PM6"}
+
+    @classmethod
+    def get_model_chemistry_options(cls, periodic_only=False, mdi_only=False):
+        """Return the model chemistries MOPAC can provide.
+
+        NOTE: only covers methods present in metadata["computational
+        models"]. As of 2026-06-22 this includes PM7, PM7-TS, PM6,
+        PM6-ORG, PM6-D3, PM6-DH+, PM6-DH2, PM6-DH2X, PM6-D3H4, PM6-D3H4X,
+        AM1, RM1, PM3, MNDO, MNDOD.
+
+        Parameters
+        ----------
+        periodic_only : bool
+            Only return options confirmed to work for a periodic system
+            via MDI -- conservative by design, a method is only included
+            if it has actually been run periodic and validated, not
+            because some other flag suggests it should work.
+        mdi_only : bool
+            Only return options actually launchable via mopac_mdi.py, as
+            opposed to only available through this step's traditional
+            batch/file-based path.
+
+        Returns
+        -------
+        dict
+            Keyed by bare method name (e.g. "PM6-ORG"). Each value has::
+
+                model_chemistry  : str   -- "MOPAC:SQM@<name>"
+                type             : str   -- always "SQM" currently
+                description      : str
+                periodic_native  : bool  -- this method's own metadata flag
+                periodic_mdi     : bool  -- actually validated periodic via MDI
+                elements         : str   -- genuine NDDO Hamiltonian coverage
+                sparkle_elements : str or None -- lanthanides reachable only
+                                   via the Sparkle point-charge model
+                                   (currently documented for PM7/PM7-TS/PM6
+                                   only; None elsewhere, which may mean "not
+                                   applicable" or "not yet checked" -- see
+                                   NOTES_mopac_model_chemistry_metadata.rst)
+                mdi_capable      : bool
+                mdi_script       : str or None
+                mdi_method_arg   : str or None
+        """
+        options = {}
+        for theory_class, class_data in mopac_step.metadata[
+            "computational models"
+        ].items():
+            for family, family_data in class_data["models"].items():
+                for name, param in family_data["parameterizations"].items():
+                    mdi_capable = name in cls._MDI_CAPABLE_METHODS
+                    periodic_mdi = name in cls._MDI_PERIODIC_VALIDATED
+
+                    if periodic_only and not periodic_mdi:
+                        continue
+                    if mdi_only and not mdi_capable:
+                        continue
+
+                    options[name] = {
+                        "model_chemistry": f"MOPAC:SQM@{name}",
+                        "type": "SQM",
+                        "description": param.get("description", ""),
+                        "periodic_native": param.get("periodic", False),
+                        "periodic_mdi": periodic_mdi,
+                        "elements": param.get("elements", ""),
+                        "sparkle_elements": param.get("sparkle_elements"),
+                        "mdi_capable": mdi_capable,
+                        "mdi_script": "mopac_mdi.py" if mdi_capable else None,
+                        "mdi_method_arg": name if mdi_capable else None,
+                    }
+        return options

--- a/mopac_step/mopac_step.py
+++ b/mopac_step/mopac_step.py
@@ -3,6 +3,12 @@
 
 """Main module."""
 
+import configparser
+import importlib.resources
+import os
+import shutil
+from pathlib import Path
+
 import mopac_step
 
 
@@ -122,7 +128,189 @@ class MOPACStep(object):
                         "elements": param.get("elements", ""),
                         "sparkle_elements": param.get("sparkle_elements"),
                         "mdi_capable": mdi_capable,
-                        "mdi_script": "mopac_mdi.py" if mdi_capable else None,
                         "mdi_method_arg": name if mdi_capable else None,
                     }
         return options
+
+    # Patch to mopac_step/mopac_step.py -- add to the MOPACStep class,
+    # alongside get_model_chemistry_options().
+    #
+    # 2026-06-23: executor configuration for the MDI engine (Option C --
+    # the engine script is shipped inside this package, at
+    # data/mopac_mdi.py, so it is refreshed by `pip install -U mopac-step`
+    # and never depends on the user re-running the step installer to
+    # refresh the seamm-mopac environment).
+
+    @classmethod
+    def get_executor_config(cls, executor, seamm_options):
+        """Return how to launch MOPAC (and its MDI engine) on this machine.
+
+        Reads the per-plug-in ``mopac.ini`` for the *current* executor type
+        exactly as ``MOPAC.run()`` does, so the MDI engine runs in the same
+        conda/local/modules/docker environment as ordinary MOPAC jobs. Adds
+        one key, ``mdi_script`` -- the absolute path to the bundled
+        ``data/mopac_mdi.py`` engine.
+
+        ``mopac_mdi.py`` imports only packages present in ``seamm-mopac``
+        (``mopactools``, ``pymdi``/``mdi``, ``numpy``, ``seamm_util``) and
+        nothing from ``mopac_step`` or ``seamm``, so it runs correctly under
+        that environment's Python even though the file physically lives in
+        the ``seamm`` environment's site-packages.
+
+        Parameters
+        ----------
+        executor : seamm.ExecutorBase
+            The flowchart executor, typically ``self.flowchart.executor`` in
+            the calling (driver) step. ``executor.name`` selects the ini
+            section.
+        seamm_options : dict
+            The global SEAMM options, typically ``self.global_options`` in
+            the calling step. ``seamm_options["root"]`` locates the ini.
+
+        Returns
+        -------
+        dict
+            The ini section for the current executor (``installation``,
+            ``code``, ``conda``, ``conda-environment``, ...), plus::
+
+                version    : str  -- this plug-in's version (container tag)
+                mdi_script : str  -- absolute path to data/mopac_mdi.py
+        """
+        executor_type = executor.name
+        ini_dir = Path(seamm_options["root"]).expanduser()
+        ini_path = ini_dir / "mopac.ini"
+        resources = importlib.resources.files("mopac_step") / "data"
+
+        # Bootstrap a default mopac.ini if the user has none yet, mirroring
+        # the [local] conda/conda-environment defaults written by
+        # MOPAC.run(). Written with configparser primitives to avoid pulling
+        # in seamm_util.Configuration here. In practice mopac.ini almost
+        # always already exists by the time an MDI run is launched, since
+        # seamm-mopac must be installed for the engine to import mopactools.
+        if not ini_path.exists():
+            boot = configparser.ConfigParser()
+            boot.read_string((resources / "mopac.ini").read_text())
+            if "local" not in boot:
+                boot.add_section("local")
+            boot["local"]["conda"] = os.environ["CONDA_EXE"]
+            boot["local"]["conda-environment"] = "seamm-mopac"
+            with ini_path.open("w") as fd:
+                boot.write(fd)
+
+        full_config = configparser.ConfigParser()
+        full_config.read(ini_path)
+
+        # Last-ditch: fall back to an executable on $PATH.
+        if executor_type not in full_config:
+            path = shutil.which("mopac")
+            if path is None:
+                raise RuntimeError(
+                    f"No section for '{executor_type}' in the MOPAC ini file "
+                    f"({ini_path}), nor in the defaults, nor on $PATH."
+                )
+            full_config.add_section(executor_type)
+            full_config.set(executor_type, "installation", "local")
+            full_config.set(executor_type, "code", str(path))
+            with ini_path.open("w") as fd:
+                full_config.write(fd)
+
+        config = dict(full_config.items(executor_type))
+        config["version"] = mopac_step.__version__
+        config["mdi_script"] = str(resources / "mopac_mdi.py")
+        return config
+
+    @classmethod
+    def get_mdi_engine_command(
+        cls,
+        executor,
+        seamm_options,
+        *,
+        method,
+        port,
+        hostname="localhost",
+        charge=0,
+        multiplicity=1,
+        engine_name="MOPAC",
+        extra_args=None,
+    ):
+        """Build the argv that launches the MOPAC MDI *engine* over TCP.
+
+        The MDI transport coordination (TCP, ``port``, ``hostname``) is
+        decided by the *driver* (e.g. lammps_step), which owns the rendezvous
+        and must give the same values to both sides, and is passed in here.
+        Everything MOPAC-specific -- the conda environment, the bundled
+        ``mopac_mdi.py`` path, the engine's MDI name, and the method /
+        charge / multiplicity flags -- is supplied by this step, so the
+        driver hardwires no MOPAC knowledge.
+
+        Parameters
+        ----------
+        executor, seamm_options
+            Passed straight to ``get_executor_config`` to locate the conda
+            environment and the bundled engine script.
+        method : str
+            Semiempirical method, e.g. "PM6-ORG". Must be one of
+            ``cls._MDI_CAPABLE_METHODS`` (== the engine's --method choices).
+        port : int
+            TCP port the engine binds; chosen by the driver.
+        hostname : str
+            Host the engine binds / the driver connects to (default
+            "localhost").
+        charge, multiplicity : int
+            Default total charge and 2S+1 multiplicity. Overridden at run
+            time if the driver sends >TOTCHARGE / >ELEC_MULT (LAMMPS's
+            fix mdi/qm currently does not).
+        engine_name : str
+            The MDI ``-name`` for the engine and what it returns for <NAME;
+            must match the driver's expectation (default "MOPAC").
+        extra_args : list of str, optional
+            Extra engine flags appended verbatim, e.g.
+            ``["--mozyme", "--tolerance", "0.5"]``.
+
+        Returns
+        -------
+        list of str
+            A ready-to-run argv. Render into the launch script with
+            ``shlex.join(argv)``.
+        """
+        if method not in cls._MDI_CAPABLE_METHODS:
+            raise ValueError(
+                f"'{method}' is not an MDI-capable MOPAC method; expected "
+                f"one of {sorted(cls._MDI_CAPABLE_METHODS)}."
+            )
+
+        config = cls.get_executor_config(executor, seamm_options)
+
+        installation = config.get("installation", "conda")
+        if installation != "conda":
+            raise NotImplementedError(
+                "The MOPAC MDI engine is currently wired up only for a conda "
+                f"installation; mopac.ini selects '{installation}'. "
+                "TODO (Phase B+): local / modules / docker launches."
+            )
+
+        mdi_init = (
+            f"-role ENGINE -name {engine_name} -method TCP "
+            f"-port {port} -hostname {hostname}"
+        )
+
+        argv = [
+            config["conda"],
+            "run",
+            "--live-stream",
+            "-n",
+            config["conda-environment"],
+            "python",
+            config["mdi_script"],
+            "-mdi",
+            mdi_init,
+            "--method",
+            method,
+            "--charge",
+            str(charge),
+            "--multiplicity",
+            str(multiplicity),
+        ]
+        if extra_args:
+            argv.extend(extra_args)
+        return argv

--- a/tests/test_get_model_chemistry_options.py
+++ b/tests/test_get_model_chemistry_options.py
@@ -82,7 +82,6 @@ def test_mdi_only_returns_exactly_the_mopactools_scope():
     assert set(options.keys()) == EXPECTED_MDI_CAPABLE
     for name, info in options.items():
         assert info["mdi_capable"] is True
-        assert info["mdi_script"] == "mopac_mdi.py"
         assert info["mdi_method_arg"] == name
 
 
@@ -128,7 +127,6 @@ def test_non_mdi_method_has_no_launch_info():
     options = mopac_step.MOPACStep.get_model_chemistry_options()
     info = options["PM6-D3"]
     assert info["mdi_capable"] is False
-    assert info["mdi_script"] is None
     assert info["mdi_method_arg"] is None
 
 

--- a/tests/test_get_model_chemistry_options.py
+++ b/tests/test_get_model_chemistry_options.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""Tests for MOPACStep.get_model_chemistry_options().
+
+These exercise the metadata-driven model-chemistry protocol described in
+docs/developer_guide/campaigns/2026-06-22/PLAN_model_chemistry_step.rst,
+specifically the MOPAC implementation. See also
+NOTES_mopac_model_chemistry_metadata.rst for the metadata corrections
+these tests are written against (real element coverage extracted from
+MOPAC's own parameter source, the Sparkle/lanthanide distinction, and
+the open question about whether SPARKLES is reachable via the MDI path
+at all).
+"""
+
+import pytest  # noqa: F401
+
+import mopac_step
+
+# Mirrors MOPACStep._MDI_CAPABLE_METHODS -- mopactools.api.MopacSystem's
+# model_dict scope, independently restated here so a future accidental
+# edit to one doesn't silently agree with itself.
+EXPECTED_MDI_CAPABLE = {"PM7", "PM6-D3H4", "PM6-ORG", "PM6", "AM1", "RM1"}
+
+# Mirrors MOPACStep._MDI_PERIODIC_VALIDATED -- methods actually run
+# periodic via MDI and confirmed working this week, per
+# NOTES_qm_mdi_engines_validation.rst.
+EXPECTED_PERIODIC_VALIDATED = {"PM7", "PM6-ORG", "PM6"}
+
+# Methods with a documented sparkle_elements entry as of 2026-06-22+.
+# All ten PM7/PM6-family parameterizations share the same core NDDO
+# Hamiltonian, so all share the same elements/sparkle_elements coverage
+# -- per Paul, the dispersion/H-bond/halogen-bond correction terms on
+# the six PM6 variants are either general (D3 dispersion) or simply
+# inactive (contribute zero) for elements outside their specific
+# domain, so they don't narrow what the underlying calculation can
+# actually run on. This applies regardless of each variant's own
+# periodic_mdi status (e.g. PM6-D3H4/D3H4X are still excluded from
+# periodic+MDI use, but that's a periodicity question, independent of
+# which elements/lanthanide-Sparkle treatment applies).
+#
+# RM1 deliberately excluded despite also covering lanthanides: its
+# parameters are real NDDO data for the full La-Lu range, not
+# Sparkle-only like PM6/PM7's Ce-Yb gap -- a materially different
+# situation despite both involving the same block of elements.
+EXPECTED_HAS_SPARKLE_ELEMENTS = {
+    "PM7",
+    "PM7-TS",
+    "PM6",
+    "PM6-ORG",
+    "PM6-D3",
+    "PM6-DH+",
+    "PM6-DH2",
+    "PM6-DH2X",
+    "PM6-D3H4",
+    "PM6-D3H4X",
+}
+
+
+def _all_metadata_names():
+    """Every parameterization name present in the raw metadata, computed
+    independently of the classmethod under test."""
+    names = set()
+    for class_data in mopac_step.metadata["computational models"].values():
+        for family_data in class_data["models"].values():
+            names |= set(family_data["parameterizations"].keys())
+    return names
+
+
+def test_no_filters_returns_everything_in_metadata():
+    """With no filters, every parameterization in metadata["computational
+    models"] should appear, and nothing else."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options()
+    assert set(options.keys()) == _all_metadata_names()
+    # Sanity check this is non-trivial, not two empty sets agreeing.
+    assert len(options) >= 15
+
+
+def test_mdi_only_returns_exactly_the_mopactools_scope():
+    """mdi_only=True should return exactly the methods mopactools'
+    model_dict supports -- no more, no less -- each with launch info
+    filled in."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options(mdi_only=True)
+    assert set(options.keys()) == EXPECTED_MDI_CAPABLE
+    for name, info in options.items():
+        assert info["mdi_capable"] is True
+        assert info["mdi_script"] == "mopac_mdi.py"
+        assert info["mdi_method_arg"] == name
+
+
+def test_periodic_only_returns_exactly_the_validated_three():
+    """periodic_only=True is deliberately conservative: only methods
+    actually run periodic via MDI and confirmed working, never just
+    because some metadata flag suggests a method should work."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options(periodic_only=True)
+    assert set(options.keys()) == EXPECTED_PERIODIC_VALIDATED
+    for info in options.values():
+        assert info["periodic_mdi"] is True
+
+
+def test_periodic_and_mdi_together_is_consistent():
+    """Combining both filters should not add anything beyond the
+    periodic-validated set, since all three validated methods are also
+    MDI-capable by construction."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options(
+        periodic_only=True, mdi_only=True
+    )
+    assert set(options.keys()) == EXPECTED_PERIODIC_VALIDATED
+
+
+def test_pm6_d3h4_is_mdi_capable_but_not_periodic_validated():
+    """PM6-D3H4 is the known trap this protocol exists to catch: it IS
+    in mopactools' model_dict (mdi_capable=True), but MOPAC's own
+    documentation says D3H4 does not work under periodic boundary
+    conditions, so it must never appear when periodic_only is True."""
+    all_options = mopac_step.MOPACStep.get_model_chemistry_options()
+    assert all_options["PM6-D3H4"]["mdi_capable"] is True
+    assert all_options["PM6-D3H4"]["periodic_mdi"] is False
+
+    periodic_options = mopac_step.MOPACStep.get_model_chemistry_options(
+        periodic_only=True
+    )
+    assert "PM6-D3H4" not in periodic_options
+
+
+def test_non_mdi_method_has_no_launch_info():
+    """A method outside mopactools' scope (e.g. PM6-D3, a correction
+    variant not in the six-method MDI list) should report
+    mdi_capable=False and no script/arg to launch with."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options()
+    info = options["PM6-D3"]
+    assert info["mdi_capable"] is False
+    assert info["mdi_script"] is None
+    assert info["mdi_method_arg"] is None
+
+
+def test_am1_and_rm1_present_as_mdi_capable():
+    """AM1 and RM1 were added to metadata.py after the original MDI
+    scope was first established from mopactools alone -- confirm they
+    now appear correctly now that real metadata entries exist for them."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options(mdi_only=True)
+    assert "AM1" in options
+    assert "RM1" in options
+    assert options["AM1"]["type"] == "SQM"
+    assert options["RM1"]["type"] == "SQM"
+
+
+def test_model_chemistry_string_format():
+    """The citable model-chemistry string should always be
+    "MOPAC:SQM@<method name>", per the established nomenclature."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options()
+    for name, info in options.items():
+        assert info["model_chemistry"] == f"MOPAC:SQM@{name}"
+
+
+def test_sparkle_elements_present_only_where_documented():
+    """All ten PM7/PM6-family parameterizations document a
+    sparkle_elements field (same core NDDO Hamiltonian, same lanthanide
+    treatment across all variants, including the six dispersion/H-bond/
+    halogen-bond correction methods -- those correction terms are either
+    general or simply inactive for elements outside their own domain,
+    so they don't narrow elemental coverage). RM1 also covers
+    lanthanides but via genuine NDDO parameters for the full La-Lu
+    range rather than the Sparkle-only Ce-Yb gap PM6/PM7 have, so it
+    correctly has no sparkle_elements entry. AM1/PM3/MNDO/MNDOD don't
+    reach the lanthanide block at all, so no Sparkle question arises
+    for them either.
+
+    This is checked against the classmethod's own output, not by
+    re-walking raw metadata -- the point is to catch exactly the kind
+    of "added to metadata but never wired into the classmethod" gap
+    that this field hit on its first draft.
+    """
+    options = mopac_step.MOPACStep.get_model_chemistry_options()
+    for name, info in options.items():
+        if name in EXPECTED_HAS_SPARKLE_ELEMENTS:
+            assert (
+                info["sparkle_elements"] is not None
+            ), f"{name} should have a sparkle_elements value"
+        else:
+            assert info["sparkle_elements"] is None, (
+                f"{name} unexpectedly has a sparkle_elements value -- "
+                "update EXPECTED_HAS_SPARKLE_ELEMENTS if this is "
+                "intentional, e.g. after checking RM1's lanthanide "
+                "treatment more carefully"
+            )
+
+
+def test_elements_field_present_for_every_option():
+    """Every option should at least have a (possibly empty) elements
+    string -- catches a future entry added to metadata.py without an
+    "elements" key at all, which param.get("elements", "") would
+    otherwise silently paper over."""
+    options = mopac_step.MOPACStep.get_model_chemistry_options()
+    for name, info in options.items():
+        assert isinstance(info["elements"], str)
+        assert info["elements"] != "", (
+            f"{name} has an empty elements string -- likely a missing "
+            "metadata entry rather than a genuine empty range"
+        )

--- a/tests/test_mdi_methods.py
+++ b/tests/test_mdi_methods.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Guard tests keeping the MDI method sets in lock-step across two files.
+
+The set of MOPAC semiempirical methods reachable through the MDI engine is
+declared in two places that must agree:
+
+* ``mopac_step/mopac_step.py``      -- ``MOPACStep._MDI_CAPABLE_METHODS``
+* ``mopac_step/data/mopac_mdi.py``  -- the argparse ``--method`` ``choices``
+
+If they drift, ``get_model_chemistry_options(mdi_only=True)`` will advertise a
+method the engine refuses (or hide one it accepts). These tests fail loudly
+when that happens.
+
+``mopac_mdi.py`` is read as text and parsed with :mod:`ast` rather than
+imported, because (a) it lives in ``data/`` and is not an importable module,
+and (b) it is written to run under the ``seamm-mopac`` environment, so
+importing it here -- in the ``seamm`` test environment -- could fail on
+``mopactools`` / ``mdi`` that are not installed on this side.
+"""
+
+import ast
+import importlib.resources
+
+from mopac_step.mopac_step import MOPACStep
+
+
+def _engine_method_choices():
+    """Return the ``--method`` ``choices`` list from ``data/mopac_mdi.py``.
+
+    Walks the AST for an ``add_argument('--method', ..., choices=[...])``
+    call and returns the literal string choices, without importing or
+    executing the engine script.
+    """
+    source = (
+        importlib.resources.files("mopac_step") / "data" / "mopac_mdi.py"
+    ).read_text()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_argument"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if not (isinstance(first, ast.Constant) and first.value == "--method"):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "choices":
+                return [
+                    elt.value for elt in kw.value.elts if isinstance(elt, ast.Constant)
+                ]
+        raise AssertionError(
+            "Found the --method argument in data/mopac_mdi.py but it has no "
+            "choices=[...] keyword."
+        )
+
+    raise AssertionError(
+        "Could not find an add_argument('--method', ..., choices=[...]) call "
+        "in data/mopac_mdi.py."
+    )
+
+
+def test_mdi_capable_methods_match_engine_choices():
+    """``_MDI_CAPABLE_METHODS`` must equal the engine's ``--method`` choices."""
+    engine_choices = set(_engine_method_choices())
+    advertised = set(MOPACStep._MDI_CAPABLE_METHODS)
+
+    missing_in_engine = advertised - engine_choices
+    missing_in_step = engine_choices - advertised
+
+    assert not missing_in_engine, (
+        "MOPACStep._MDI_CAPABLE_METHODS advertises methods the engine does "
+        f"not accept via --method: {sorted(missing_in_engine)}. Either add "
+        "them to mopac_mdi.py's --method choices or remove them from "
+        "_MDI_CAPABLE_METHODS."
+    )
+    assert not missing_in_step, (
+        "data/mopac_mdi.py --method accepts choices not advertised in "
+        f"MOPACStep._MDI_CAPABLE_METHODS: {sorted(missing_in_step)}. Either "
+        "add them to _MDI_CAPABLE_METHODS or remove them from the engine's "
+        "--method choices."
+    )
+
+
+def test_periodic_validated_is_subset_of_capable():
+    """Every periodic-validated method must also be MDI-capable.
+
+    A method cannot be validated periodic via MDI unless it is reachable via
+    MDI in the first place, so ``_MDI_PERIODIC_VALIDATED`` must be a subset of
+    ``_MDI_CAPABLE_METHODS``.
+    """
+    capable = set(MOPACStep._MDI_CAPABLE_METHODS)
+    periodic = set(MOPACStep._MDI_PERIODIC_VALIDATED)
+
+    extra = periodic - capable
+    assert not extra, (
+        "_MDI_PERIODIC_VALIDATED contains methods absent from "
+        f"_MDI_CAPABLE_METHODS: {sorted(extra)}"
+    )


### PR DESCRIPTION
* get_model_chemistry_options() protocol works end-to-end for MOPAC — real metadata (corrected element ranges, the Sparkle/lanthanide distinction, all ten PM6/PM7-family entries consistently treated), tests passing against it, docs building clean with the cross-reference back to the campaign plan.
* Still unknown: Whether SPARKLES is reachable through the MDI path at all. If mopactools's MopacSystem has no keyword-injection mechanism, any La/Lu/Ce–Yb-containing system may be unrunnable via mopac_mdi.py regardless of what the metadata says — this hasn't been checked against the real API yet.