### PR TITLE
Bugfix: run MOPAC single-threaded when driven over MDI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,16 @@
 =======
 History
 =======
+2026.7.27 -- Bugfix: run MOPAC single-threaded when driven over MDI
+    * When another step drove MOPAC through the MDI engine (QM/MD, and the Dimer
+      Builder's energy-based contact), MOPAC was not held to a single thread the
+      way a normal MOPAC step is, so it spread across all available cores. Since
+      these drivers issue many small calls one after another, the extra threads
+      only oversubscribed the cores and could slow the run. The MDI engine now
+      pins MOPAC -- and the linear-algebra libraries it calls -- to a single
+      thread, matching the normal MOPAC step. Set ``OMP_NUM_THREADS`` in the
+      environment to override.
+
 2026.7.6 -- Quieter MDI engine logging
     * The MDI engine used to drive MOPAC from other steps (QM/MD, and the Dimer
       Builder's energy-based contact) logged its connection, setup, and timing

--- a/mopac_step/data/mopac_mdi.py
+++ b/mopac_step/data/mopac_mdi.py
@@ -60,17 +60,33 @@ Logging: three levels, set via --log-level.
     WARNING -- only warnings and errors (quietest)
 """
 
-import argparse
-import logging
-import sys
-import time
-import numpy as np
+# Pin MOPAC (and the BLAS/LAPACK it calls) to a single thread. MOPAC gets little
+# benefit from threading on these small semiempirical SCFs, and an MDI driver
+# typically issues many calls back-to-back, so multiple threads only
+# oversubscribe the cores. Unlike the normal MOPAC step -- which launches MOPAC
+# with an explicit OMP_NUM_THREADS -- this engine is spawned by the MDI driver
+# with an inherited environment, so nothing else caps the thread count. Set the
+# caps here, before numpy (and hence any MKL/OpenBLAS runtime) is imported, or
+# the thread pool is already sized and the setting is ignored. `setdefault`
+# leaves an explicitly-set environment override in place.
+import os
 
-from seamm_util import Q_
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+
+import argparse  # noqa: E402
+import logging  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+from seamm_util import Q_  # noqa: E402
 
 # mpi4py only needed for -method MPI; harmless if unused for TCP.
 try:
-    from mpi4py import MPI  # noqa: F401
+    from mpi4py import MPI  # noqa: E402, F401
 except ImportError:
     pass
 

--- a/mopac_step/mopac_step.py
+++ b/mopac_step/mopac_step.py
@@ -264,7 +264,9 @@ class MOPACStep(object):
         n_atoms : int, optional
             Accepted for interface parity with other engines, but ignored:
             MOPAC does not use threading effectively, so its engine stays
-            single-threaded (the launch script's OMP cap applies).
+            single-threaded. The bundled ``mopac_mdi.py`` pins
+            OMP/MKL/OpenBLAS to one thread at import (this MDI engine is spawned
+            with an inherited environment, so nothing else caps it).
         engine_name : str
             The MDI ``-name`` for the engine and what it returns for <NAME;
             must match the driver's expectation (default "MOPAC").


### PR DESCRIPTION
* When another step drove MOPAC through the MDI engine (QM/MD, and the Dimer Builder's energy-based contact), MOPAC was not held to a single thread the way a normal MOPAC step is, so it spread across all available cores. Since these drivers issue many small calls one after another, the extra threads only oversubscribed the cores and could slow the run. The MDI engine now pins MOPAC -- and the linear-algebra libraries it calls -- to a single thread, matching the normal MOPAC step. Set `OMP_NUM_THREADS` in the environment to override.